### PR TITLE
DBE-26620 couchbase 6.6/7.0: switch GSI storage to plasma to fix flak…

### DIFF
--- a/couchbase/6.6/config.sh
+++ b/couchbase/6.6/config.sh
@@ -44,7 +44,7 @@ curl -v -X POST http://127.0.0.1:8091/settings/indexes \
 -d maxRollbackPoints=5 \
 -d memorySnapshotInterval=200 \
 -d stableSnapshotInterval=5000 \
--d storageMode=memory_optimized
+-d storageMode=plasma
 
 curl -v -X  PUT -u Administrator:password \
 http://localhost:8091/settings/rbac/users/local/admin \

--- a/couchbase/7.0/config.sh
+++ b/couchbase/7.0/config.sh
@@ -69,7 +69,7 @@ curl -v -X POST http://127.0.0.1:8091/settings/indexes \
 -d maxRollbackPoints=5 \
 -d memorySnapshotInterval=200 \
 -d stableSnapshotInterval=5000 \
--d storageMode=memory_optimized
+-d storageMode=plasma
 
 # admin user
 curl -v -X  PUT -u Administrator:password \


### PR DESCRIPTION
  The Couchbase 6.6 and 7.0 test images use memory_optimized GSI (global secondary index) storage, which keeps indexes in RAM. At these images' index memory quota, building a second index on a bucket     
  isn't reliable — the build stalls past the JDBC driver's 60s waitUntilReady, which flakes DataGrip's Couchbase parametrized tests (ObjectScriptingTest, IntrospectorTest, DataGridExtractionTest).        
                                                                                                                                                                                                            
  Fix: switch 6.6 and 7.0 to plasma storage (disk-backed, insensitive to index memory quota).                                                                                                               
                                                                                                                                                                                                            
  Why this is safe:                                                                                                                                                                                         
  - A standalone reproducer against couchbase-server:7 failed 5/6 secondary-index builds with memory_optimized at 1024 MB index quota, and passed 6/6 at 2048 MB — confirming the quota/RAM link.           
  - 8.0 already uses plasma, so this brings 6.6 and 7.0 in line with it.                                                                                                                                    
                                                                                                                                                                                                            
  Changes: couchbase/6.6/config.sh, couchbase/7.0/config.sh (one line each).